### PR TITLE
Added missing comma to "undamaged" value in json string

### DIFF
--- a/Plugin.cs
+++ b/Plugin.cs
@@ -77,7 +77,7 @@ namespace ConquestBotMod
                             }
                             streamWriter.WriteLine(string.Format(string.Format("                        \"destroyed\": {0},", num)));
                             streamWriter.WriteLine(string.Format(string.Format("                        \"damaged\": {0},", num2)));
-                            streamWriter.WriteLine(string.Format(string.Format("                        \"undamaged\": {0}", num3)));
+                            streamWriter.WriteLine(string.Format(string.Format("                        \"undamaged\": {0},", num3)));
                             streamWriter.WriteLine("                        \"components\": {");
                             foreach (ShipComponent component in ESD.Components) {
                                 streamWriter.WriteLine($"                            \"{component.Name}\": {{");


### PR DESCRIPTION
This is a possible fix to the #1 "Json file formatting issue with "damaged" property" issue I reported.

Thanks again @HobbitJack ! 